### PR TITLE
Adding Accept-Encoding header

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -38,7 +38,6 @@ function hit () {
   var req = format('GET %s HTTP/1.1\r\n', options.url.path)
     + format('Host: %s\r\n', options.url.host)
     + format('Accept-Encoding: gzip,deflate,sdch\r\n')
-    + format('Connection: keep-alive')
     + 'Connection: close\r\n\r\n';
 
   var data = '';


### PR DESCRIPTION
Adding ability to accept gzip,compress header to more close emulate a
real request.

This allows your tool to more closely emulate scripts like siege that, by default, apply the accept encoding header.

Additionally maybe you could also add the --header directive as well to pass additional header types.
